### PR TITLE
Fix HTTPClient to use system properties and use proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,10 @@ description = "XE Currency Data API Client"
 def ossrhUsername = project.findProperty('ossrhUsername') ?: null;
 def ossrhPassword = project.findProperty('ossrhPassword') ?: null;
 
+repositories {
+    jcenter()
+}
+
 task javadocJar(type: Jar) {
     classifier = 'javadoc'
     from javadoc

--- a/src/main/java/com/xe/xecdApiClient/service/XecdHttpClientImpl.java
+++ b/src/main/java/com/xe/xecdApiClient/service/XecdHttpClientImpl.java
@@ -31,7 +31,7 @@ public class XecdHttpClientImpl implements XecdHttpClient
 
 	public XecdHttpClientImpl(Integer connectTimeout)
 	{
-		HttpClientBuilder builder = HttpClientBuilder.create();
+		HttpClientBuilder builder = HttpClientBuilder.create().useSystemProperties();
 		if (connectTimeout != null)
 		{
 			RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(connectTimeout).build();


### PR DESCRIPTION
To be able to configure and use behind a proxy.
Cf.:
- https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html
- https://hc.apache.org/httpcomponents-client-4.5.x/tutorial/html/connmgmt.html#d5e485