### PR TITLE
Enabling useSystemProperties on http client

### DIFF
--- a/src/main/java/com/xe/xecdApiClient/config/XecdApiConfigBean.java
+++ b/src/main/java/com/xe/xecdApiClient/config/XecdApiConfigBean.java
@@ -9,6 +9,7 @@ public class XecdApiConfigBean
 	private String apiKey;
 	private String serverPrefix;
 	private Integer connectTimeout;
+	private Boolean useSystemProperties;
 
 	public String getAccountId()
 	{
@@ -54,5 +55,13 @@ public class XecdApiConfigBean
 	public void setConnectTimeout(Integer connectTimeout)
 	{
 		this.connectTimeout = connectTimeout;
+	}
+
+	public Boolean useSystemProperties() {
+		return useSystemProperties;
+	}
+
+	public void setUseSystemProperties(final Boolean useSystemProperties) {
+		this.useSystemProperties = useSystemProperties;
 	}
 }

--- a/src/main/java/com/xe/xecdApiClient/service/XecdApiServiceImpl.java
+++ b/src/main/java/com/xe/xecdApiClient/service/XecdApiServiceImpl.java
@@ -61,30 +61,30 @@ public class XecdApiServiceImpl implements XecdApiService
 		this.apiKey = config.getApiKey();
 		this.serverPrefix = config.getServerPrefix() != null ? config.getServerPrefix() : this.serverPrefix;
 		this.jsonUtils = new JsonUtils();
-		this.wsClient = new XecdHttpClientImpl(config.getConnectTimeout());
+		this.wsClient = new XecdHttpClientImpl(config.getConnectTimeout(), config.useSystemProperties());
 	}
 
 	/**
 	 * Looks at the environment variables to satisfy required properties
 	 * - XECD_ACCOUNT_ID
 	 * - XECD_API_KEY
-	 * @throws XecdApiException 
+	 * @throws XecdApiException
 	 */
 	XecdApiServiceImpl() throws XecdApiException
 	{
 		String apiKeyVar = System.getenv("XECD_API_KEY");
 		String accountIdVar = System.getenv("XECD_ACCOUNT_ID");
-		
-		this.wsClient = new XecdHttpClientImpl(null);
-		
+
+		this.wsClient = new XecdHttpClientImpl(null, null);
+
 		if(apiKeyVar != null && accountIdVar != null && !apiKeyVar.isEmpty() && !accountIdVar.isEmpty())
 		{
 			logger.debug("INITIALIZING WITH ENVIRONMENT VARIABLES");
-			
+
 			this.apiKey = System.getenv("XECD_API_KEY");
 			this.accountId = System.getenv("XECD_ACCOUNT_ID");
 			this.jsonUtils = new JsonUtils();
-			
+
 		}
 		else
 		{

--- a/src/main/java/com/xe/xecdApiClient/service/XecdHttpClientImpl.java
+++ b/src/main/java/com/xe/xecdApiClient/service/XecdHttpClientImpl.java
@@ -29,13 +29,16 @@ public class XecdHttpClientImpl implements XecdHttpClient
 
 	private HttpClient client = null;
 
-	public XecdHttpClientImpl(Integer connectTimeout)
+	public XecdHttpClientImpl(Integer connectTimeout, Boolean useSystemProperties)
 	{
 		HttpClientBuilder builder = HttpClientBuilder.create();
 		if (connectTimeout != null)
 		{
 			RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(connectTimeout).build();
 			builder.setDefaultRequestConfig(requestConfig);
+		}
+		if(useSystemProperties != null && useSystemProperties) {
+			builder.useSystemProperties();
 		}
 		try
 		{


### PR DESCRIPTION
**WHAT**

Adding  `useSystemPropeties` to XecdApiConfigBean.java So that users of this client libarary optinally can set the value. So that they can use the functionalites provided by the underline apache HTTP client for vaious requirements like proxy settingis one of them. 

**WHY**
Today there is no way to set user settings on the underline Apache HTTP client.  Apart from connectionTimeout, there are various properties that customers can enable on the HTTP client.
One of them is `useSystemPropeties`.

